### PR TITLE
raidboss: update cn translation

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -196,7 +196,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Zeige ${side}/${dir} Verbindung weg',
           fr: 'Orientez le lien à l\'extérieur - ${side}/${dir}',
           ja: '線伸ばし ${side}/${dir}',
-          cn: '向 ${side}/${dir} 外侧引导',
+          cn: '向 ${dir} 外侧引导',
           ko: '선을 ${side}/${dir}으로',
         },
         default: {


### PR DESCRIPTION
The dir of cn's outputs already includes the side field.

before:
![image](https://github.com/Souma-Sumire/cactbot/assets/33572696/3cdd91f5-1494-4104-bac5-9a8097429e3d)

now:
![image](https://github.com/Souma-Sumire/cactbot/assets/33572696/3c26ad3f-c555-4fff-904f-25c3202ad497)
